### PR TITLE
New signals

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus, --keep-runtime-typing]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v2.32.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus, --keep-runtime-typing]
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/myint/autoflake
@@ -23,7 +23,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -118,3 +118,38 @@ def test_device_property_events(core: CMMCorePlus):
     core.setProperty("Camera", "Gain", "5")
     mock1.assert_not_called()
     mock2.assert_not_called()
+
+
+def test_sequence_acquisition_events(core: CMMCorePlus):
+
+    mock1 = Mock()
+    mock2 = Mock()
+    mock3 = Mock()
+
+    core.events.startContinuousSequenceAcquisition.connect(mock1)
+    core.events.stopSequenceAcquisition.connect(mock2)
+    core.events.startSequenceAcquisition.connect(mock3)
+
+    core.startContinuousSequenceAcquisition()
+    mock1.assert_has_calls([call(),])
+
+    core.stopSequenceAcquisition()
+    mock2.assert_has_calls([call(core.getCameraDevice()),])
+
+    # without camera label
+    core.startSequenceAcquisition(5, 100.0, True)
+    mock3.assert_has_calls(
+        [call(core.getCameraDevice(), 5, 100.0, True),]
+    )
+    core.stopSequenceAcquisition()
+    mock2.assert_has_calls([call(core.getCameraDevice()),])
+
+    # with camera label
+    cam = core.getCameraDevice()
+    core.startSequenceAcquisition(cam, 5, 100.0, True)
+    mock3.assert_has_calls(
+        [call(cam, 5, 100.0, True),]
+    )
+    core.stopSequenceAcquisition(cam)
+    mock2.assert_has_calls([call(cam),])
+

--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -118,3 +118,27 @@ def test_device_property_events(core: CMMCorePlus):
     core.setProperty("Camera", "Gain", "5")
     mock1.assert_not_called()
     mock2.assert_not_called()
+
+
+def test_shutter_device_events(core: CMMCorePlus):
+    mock = Mock()
+    core.events.shutterSet.connect(mock)
+    core.setShutterOpen("Shutter", True)
+    mock.assert_has_calls(
+        [
+            call("Shutter", True),
+        ]
+    )
+    assert core.getShutterOpen("Shutter")
+
+
+def test_autoshutter_device_events(core: CMMCorePlus):
+    mock = Mock()
+    core.events.autoShutterSet.connect(mock)
+    core.setAutoShutter(True)
+    mock.assert_has_calls(
+        [
+            call(True),
+        ]
+    )
+    assert core.getAutoShutter()

--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -131,25 +131,44 @@ def test_sequence_acquisition_events(core: CMMCorePlus):
     core.events.startSequenceAcquisition.connect(mock3)
 
     core.startContinuousSequenceAcquisition()
-    mock1.assert_has_calls([call(),])
+    mock1.assert_has_calls(
+        [
+            call(),
+        ]
+    )
 
     core.stopSequenceAcquisition()
-    mock2.assert_has_calls([call(core.getCameraDevice()),])
+    mock2.assert_has_calls(
+        [
+            call(core.getCameraDevice()),
+        ]
+    )
 
     # without camera label
     core.startSequenceAcquisition(5, 100.0, True)
     mock3.assert_has_calls(
-        [call(core.getCameraDevice(), 5, 100.0, True),]
+        [
+            call(core.getCameraDevice(), 5, 100.0, True),
+        ]
     )
     core.stopSequenceAcquisition()
-    mock2.assert_has_calls([call(core.getCameraDevice()),])
+    mock2.assert_has_calls(
+        [
+            call(core.getCameraDevice()),
+        ]
+    )
 
     # with camera label
     cam = core.getCameraDevice()
     core.startSequenceAcquisition(cam, 5, 100.0, True)
     mock3.assert_has_calls(
-        [call(cam, 5, 100.0, True),]
+        [
+            call(cam, 5, 100.0, True),
+        ]
     )
     core.stopSequenceAcquisition(cam)
-    mock2.assert_has_calls([call(cam),])
-
+    mock2.assert_has_calls(
+        [
+            call(cam),
+        ]
+    )

--- a/pymmcore_plus/_tests/test_events.py
+++ b/pymmcore_plus/_tests/test_events.py
@@ -172,6 +172,8 @@ def test_sequence_acquisition_events(core: CMMCorePlus):
             call(cam),
         ]
     )
+
+
 def test_shutter_device_events(core: CMMCorePlus):
     mock = Mock()
     core.events.shutterSet.connect(mock)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -694,20 +694,14 @@ class CMMCorePlus(pymmcore.CMMCore):
             cameraLabel, numImages, intervalMs, stopOnOverflow
         )
 
-    @overload
-    def stopSequenceAcquisition(self) -> None:
-        ...
-
-    @overload
-    def stopSequenceAcquisition(self, cameraLabel: str) -> None:
-        ...
-
-    def stopSequenceAcquisition(self, *args) -> None:
+    def stopSequenceAcquisition(self, cameraLabel: Optional[str] = None) -> None:
         """Stop a SequenceAcquisition."""
-        super().stopSequenceAcquisition(*args)
-        cameraLabel = args[0] if args else super().getCameraDevice()
+        if cameraLabel is None:
+            super().stopSequenceAcquisition()
+        else:
+            super().stopSequenceAcquisition(cameraLabel)
+        cameraLabel = cameraLabel or super().getCameraDevice()
         self.events.stopSequenceAcquisition.emit(cameraLabel)
-
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""
         # approx retrieval cost in comment (for demoCam)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -681,7 +681,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         intervalMs: float,
         stopOnOverflow: bool,
     ) -> None:
-        ... # pragma: no cover
+        ...  # pragma: no cover
 
     def startSequenceAcquisition(self, *args) -> None:
         super().startSequenceAcquisition(*args)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -681,7 +681,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         intervalMs: float,
         stopOnOverflow: bool,
     ) -> None:
-        ...
+        ... # pragma: no cover
 
     def startSequenceAcquisition(self, *args) -> None:
         super().startSequenceAcquisition(*args)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -684,15 +684,12 @@ class CMMCorePlus(pymmcore.CMMCore):
         ...
 
     def startSequenceAcquisition(self, *args) -> None:
+        super().startSequenceAcquisition(numImages, intervalMs, stopOnOverflow)
         if len(args) == 3:
             numImages, intervalMs, stopOnOverflow = args
-            super().startSequenceAcquisition(numImages, intervalMs, stopOnOverflow)
             cameraLabel = super().getCameraDevice()
         else:
             cameraLabel, numImages, intervalMs, stopOnOverflow = args
-            super().startSequenceAcquisition(
-                cameraLabel, numImages, intervalMs, stopOnOverflow
-            )
         self.events.startSequenceAcquisition.emit(
             cameraLabel, numImages, intervalMs, stopOnOverflow
         )

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -659,6 +659,27 @@ class CMMCorePlus(pymmcore.CMMCore):
         img = super().getImage(*args)
         return self._fix_image(img) if fix else img
 
+    def setAutoShutter(self, state: bool):
+        super().setAutoShutter(state)
+        self.events.autoShutterSet.emit(state)
+
+    @overload
+    def setShutterOpen(self, state: bool) -> int:
+        ...  # pragma: no cover
+
+    @overload
+    def setShutterOpen(self, shutterLabel: str, state: bool) -> str:
+        ...  # pragma: no cover
+
+    def setShutterOpen(self, *args):
+        super().setShutterOpen(*args)
+        if len(args) > 1:
+            shutterLabel, state = args
+        else:
+            shutterLabel = super().getShutterDevice()
+            state = args
+        self.events.shutterSet.emit(shutterLabel, state)
+
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""
         # approx retrieval cost in comment (for demoCam)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -668,16 +668,6 @@ class CMMCorePlus(pymmcore.CMMCore):
         """Stop a ContinuousSequenceAcquisition."""
         super().stopSequenceAcquisition()
         self.events.continuousSequenceAcquisition.emit(False)
-        
-    def deleteGroup(self, group_name: str)-> None:
-        """Delete a group from the system configuration."""
-        super().deleteConfigGroup(group_name)
-        self.events.groupDeleted.emit(group_name)
-    
-    def deletePreset(self, group_name: str, preset_name: str)-> None:
-        """Delete a preset from the system configuration."""
-        super().deleteConfig(group_name, preset_name)
-        self.events.groupDeleted.emit(group_name, preset_name)
 
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -663,7 +663,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         """Start a ContinuousSequenceAcquisition."""
         super().startContinuousSequenceAcquisition(0)
         self.events.continuousSequenceAcquisition.emit(True)
-        
+
     def stopSeqAcquisition(self) -> None:
         """Stop a ContinuousSequenceAcquisition."""
         super().stopSequenceAcquisition()

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -659,6 +659,26 @@ class CMMCorePlus(pymmcore.CMMCore):
         img = super().getImage(*args)
         return self._fix_image(img) if fix else img
 
+    def startContinuousSeqAcquisition(self) -> None:
+        """Start a ContinuousSequenceAcquisition."""
+        DeviceType(super().startContinuousSequenceAcquisition(0))
+        self.events.continuousSequenceAcquisition.emit(True)
+        
+    def stopSeqAcquisition(self) -> None:
+        """Stop a ContinuousSequenceAcquisition."""
+        DeviceType(super().stopSequenceAcquisition())
+        self.events.continuousSequenceAcquisition.emit(False)
+        
+    def deleteGroup(self, group_name: str)-> None:
+        """Delete a group from the system configuration."""
+        DeviceType(super().deleteConfigGroup(group_name))
+        self.events.groupDeleted.emit(group_name)
+    
+    def deletePreset(self, group_name: str, preset_name: str)-> None:
+        """Delete a preset from the system configuration."""
+        DeviceType(super().deleteConfig(group_name, preset_name))
+        self.events.groupDeleted.emit(group_name, preset_name)
+
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""
         # approx retrieval cost in comment (for demoCam)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -671,11 +671,12 @@ class CMMCorePlus(pymmcore.CMMCore):
         intervalMs: float,
         stopOnOverflow: bool,
     ) -> None:
-        super().startSequenceAcquisition(
-            numImages, intervalMs, stopOnOverflow
-        )
+        super().startSequenceAcquisition(numImages, intervalMs, stopOnOverflow)
         self.events.startSequenceAcquisition.emit(
-            super().getCameraDevice(), numImages, intervalMs, stopOnOverflow,
+            super().getCameraDevice(),
+            numImages,
+            intervalMs,
+            stopOnOverflow,
         )
 
     @overload
@@ -696,9 +697,7 @@ class CMMCorePlus(pymmcore.CMMCore):
     def startSequenceAcquisition(self, *args) -> None:
         if len(args) == 3:
             numImages, intervalMs, stopOnOverflow = args
-            super().startSequenceAcquisition(
-                numImages, intervalMs, stopOnOverflow
-            )
+            super().startSequenceAcquisition(numImages, intervalMs, stopOnOverflow)
             cameraLabel = super().getCameraDevice()
         else:
             cameraLabel, numImages, intervalMs, stopOnOverflow = args

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -671,12 +671,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         intervalMs: float,
         stopOnOverflow: bool,
     ) -> None:
-        super().startSequenceAcquisition(
-            numImages, intervalMs, stopOnOverflow
-        )
-        self.events.startSequenceAcquisition.emit(
-            super().getCameraDevice(), numImages, intervalMs, stopOnOverflow,
-        )
+        ...
 
     @overload
     def startSequenceAcquisition(
@@ -686,12 +681,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         intervalMs: float,
         stopOnOverflow: bool,
     ) -> None:
-        super().startSequenceAcquisition(
-            cameraLabel, numImages, intervalMs, stopOnOverflow
-        )
-        self.events.startSequenceAcquisition.emit(
-            cameraLabel, numImages, intervalMs, stopOnOverflow
-        )
+        ...
 
     def startSequenceAcquisition(self, *args) -> None:
         if len(args) == 3:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -671,7 +671,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         intervalMs: float,
         stopOnOverflow: bool,
     ) -> None:
-        ...
+        ...  # pragma: no cover
 
     @overload
     def startSequenceAcquisition(

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -661,22 +661,22 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def startContinuousSeqAcquisition(self) -> None:
         """Start a ContinuousSequenceAcquisition."""
-        DeviceType(super().startContinuousSequenceAcquisition(0))
+        super().startContinuousSequenceAcquisition(0)
         self.events.continuousSequenceAcquisition.emit(True)
         
     def stopSeqAcquisition(self) -> None:
         """Stop a ContinuousSequenceAcquisition."""
-        DeviceType(super().stopSequenceAcquisition())
+        super().stopSequenceAcquisition()
         self.events.continuousSequenceAcquisition.emit(False)
         
     def deleteGroup(self, group_name: str)-> None:
         """Delete a group from the system configuration."""
-        DeviceType(super().deleteConfigGroup(group_name))
+        super().deleteConfigGroup(group_name)
         self.events.groupDeleted.emit(group_name)
     
     def deletePreset(self, group_name: str, preset_name: str)-> None:
         """Delete a preset from the system configuration."""
-        DeviceType(super().deleteConfig(group_name, preset_name))
+        super().deleteConfig(group_name, preset_name)
         self.events.groupDeleted.emit(group_name, preset_name)
 
     def state(self, exclude=()) -> dict:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -669,7 +669,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         numImages: int,
         intervalMs: float,
         stopOnOverflow: bool,
-        cameraLabel: Optional[str] = None
+        cameraLabel: Optional[str] = None,
     ) -> None:
         cameraLabel = cameraLabel or super().getCameraDevice()
         super().startSequenceAcquisition(

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -659,15 +659,33 @@ class CMMCorePlus(pymmcore.CMMCore):
         img = super().getImage(*args)
         return self._fix_image(img) if fix else img
 
-    def startContinuousSeqAcquisition(self) -> None:
+    def startContinuousSequenceAcquisition(
+        self, intervalMs: float = 0
+    ) -> None:
         """Start a ContinuousSequenceAcquisition."""
-        super().startContinuousSequenceAcquisition(0)
-        self.events.continuousSequenceAcquisition.emit(True)
-        
-    def stopSeqAcquisition(self) -> None:
+        super().startContinuousSequenceAcquisition(intervalMs)
+        self.events.startContinuousSequenceAcquisition.emit()
+
+    def startSequenceAcquisition(
+        self,
+        numImages: int,
+        intervalMs: float,
+        stopOnOverflow: bool,
+        cameraLabel: Optional[str] = None
+    ) -> None:
+        cameraLabel = cameraLabel or super().getCameraDevice()
+        super().startSequenceAcquisition(
+            cameraLabel, numImages, intervalMs, stopOnOverflow
+        )
+        self.events.startSequenceAcquisition.emit(
+            cameraLabel, numImages, intervalMs, stopOnOverflow
+        )
+
+    def stopSequenceAcquisition(self, cameraLabel: Optional[str] = None) -> None:
         """Stop a ContinuousSequenceAcquisition."""
-        super().stopSequenceAcquisition()
-        self.events.continuousSequenceAcquisition.emit(False)
+        cameraLabel = cameraLabel or super().getCameraDevice()
+        super().stopSequenceAcquisition(cameraLabel)
+        self.events.stopSequenceAcquisition.emit()
 
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -702,6 +702,7 @@ class CMMCorePlus(pymmcore.CMMCore):
             super().stopSequenceAcquisition(cameraLabel)
         cameraLabel = cameraLabel or super().getCameraDevice()
         self.events.stopSequenceAcquisition.emit(cameraLabel)
+
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""
         # approx retrieval cost in comment (for demoCam)

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -684,7 +684,7 @@ class CMMCorePlus(pymmcore.CMMCore):
         ...
 
     def startSequenceAcquisition(self, *args) -> None:
-        super().startSequenceAcquisition(numImages, intervalMs, stopOnOverflow)
+        super().startSequenceAcquisition(*args)
         if len(args) == 3:
             numImages, intervalMs, stopOnOverflow = args
             cameraLabel = super().getCameraDevice()
@@ -704,12 +704,8 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def stopSequenceAcquisition(self, *args) -> None:
         """Stop a SequenceAcquisition."""
-        if args:
-            cameraLabel = args[0]
-            super().stopSequenceAcquisition(cameraLabel)
-        else:
-            super().stopSequenceAcquisition()
-            cameraLabel = super().getCameraDevice()
+        super().stopSequenceAcquisition(*args)
+        cameraLabel = args[0] if args else super().getCameraDevice()
         self.events.stopSequenceAcquisition.emit(cameraLabel)
 
     def state(self, exclude=()) -> dict:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -707,7 +707,7 @@ class CMMCorePlus(pymmcore.CMMCore):
 
     def stopSequenceAcquisition(self, *args) -> None:
         """Stop a SequenceAcquisition."""
-        if args:    
+        if args:
             cameraLabel = args[0]
             super().stopSequenceAcquisition(cameraLabel)
         else:

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -664,17 +664,47 @@ class CMMCorePlus(pymmcore.CMMCore):
         super().startContinuousSequenceAcquisition(intervalMs)
         self.events.startContinuousSequenceAcquisition.emit()
 
+    @overload
     def startSequenceAcquisition(
         self,
         numImages: int,
         intervalMs: float,
         stopOnOverflow: bool,
-        cameraLabel: Optional[str] = None,
     ) -> None:
-        cameraLabel = cameraLabel or super().getCameraDevice()
+        super().startSequenceAcquisition(
+            numImages, intervalMs, stopOnOverflow
+        )
+        self.events.startSequenceAcquisition.emit(
+            super().getCameraDevice(), numImages, intervalMs, stopOnOverflow,
+        )
+
+    @overload
+    def startSequenceAcquisition(
+        self,
+        cameraLabel: str,
+        numImages: int,
+        intervalMs: float,
+        stopOnOverflow: bool,
+    ) -> None:
         super().startSequenceAcquisition(
             cameraLabel, numImages, intervalMs, stopOnOverflow
         )
+        self.events.startSequenceAcquisition.emit(
+            cameraLabel, numImages, intervalMs, stopOnOverflow
+        )
+
+    def startSequenceAcquisition(self, *args) -> None:
+        if len(args) == 3:
+            numImages, intervalMs, stopOnOverflow = args
+            super().startSequenceAcquisition(
+                numImages, intervalMs, stopOnOverflow
+            )
+            cameraLabel = super().getCameraDevice()
+        else:
+            cameraLabel, numImages, intervalMs, stopOnOverflow = args
+            super().startSequenceAcquisition(
+                cameraLabel, numImages, intervalMs, stopOnOverflow
+            )
         self.events.startSequenceAcquisition.emit(
             cameraLabel, numImages, intervalMs, stopOnOverflow
         )

--- a/pymmcore_plus/core/_mmcore_plus.py
+++ b/pymmcore_plus/core/_mmcore_plus.py
@@ -697,11 +697,23 @@ class CMMCorePlus(pymmcore.CMMCore):
             cameraLabel, numImages, intervalMs, stopOnOverflow
         )
 
-    def stopSequenceAcquisition(self, cameraLabel: Optional[str] = None) -> None:
-        """Stop a ContinuousSequenceAcquisition."""
-        cameraLabel = cameraLabel or super().getCameraDevice()
-        super().stopSequenceAcquisition(cameraLabel)
-        self.events.stopSequenceAcquisition.emit()
+    @overload
+    def stopSequenceAcquisition(self) -> None:
+        ...
+
+    @overload
+    def stopSequenceAcquisition(self, cameraLabel: str) -> None:
+        ...
+
+    def stopSequenceAcquisition(self, *args) -> None:
+        """Stop a SequenceAcquisition."""
+        if args:    
+            cameraLabel = args[0]
+            super().stopSequenceAcquisition(cameraLabel)
+        else:
+            super().stopSequenceAcquisition()
+            cameraLabel = super().getCameraDevice()
+        self.events.stopSequenceAcquisition.emit(cameraLabel)
 
     def state(self, exclude=()) -> dict:
         """A dict with commonly accessed state values.  Faster than getSystemState."""

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -35,3 +35,6 @@ class PCoreSignaler(Protocol):
     # added for CMMCorePlus
     imageSnapped: PSignalInstance
     mdaEngineRegistered: PSignalInstance
+    continuousSequenceAcquisition: PSignalInstance
+    groupDeleted: PSignalInstance
+    presetDeleted: PSignalInstance

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -35,4 +35,7 @@ class PCoreSignaler(Protocol):
     # added for CMMCorePlus
     imageSnapped: PSignalInstance
     mdaEngineRegistered: PSignalInstance
-    continuousSequenceAcquisition: PSignalInstance
+    startContinuousSequenceAcquisition: PSignalInstance
+    startSequenceAcquisition: PSignalInstance
+    stopSequenceAcquisition: PSignalInstance
+

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -38,4 +38,3 @@ class PCoreSignaler(Protocol):
     startContinuousSequenceAcquisition: PSignalInstance
     startSequenceAcquisition: PSignalInstance
     stopSequenceAcquisition: PSignalInstance
-

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -36,5 +36,3 @@ class PCoreSignaler(Protocol):
     imageSnapped: PSignalInstance
     mdaEngineRegistered: PSignalInstance
     continuousSequenceAcquisition: PSignalInstance
-    groupDeleted: PSignalInstance
-    presetDeleted: PSignalInstance

--- a/pymmcore_plus/core/events/_protocol.py
+++ b/pymmcore_plus/core/events/_protocol.py
@@ -35,3 +35,5 @@ class PCoreSignaler(Protocol):
     # added for CMMCorePlus
     imageSnapped: PSignalInstance
     mdaEngineRegistered: PSignalInstance
+    autoShutterSet: PSignalInstance
+    shutterSet: PSignalInstance

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -25,6 +25,8 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     # added for CMMCorePlus
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
+    autoShutterSet = Signal(bool)
+    shutterSet = Signal(str, bool)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -27,7 +27,7 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
     startContinuousSequenceAcquisition = Signal()
     startSequenceAcquisition = Signal(str, int, float, bool)
-    stopSequenceAcquisition = Signal()
+    stopSequenceAcquisition = Signal(str)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -1,6 +1,8 @@
 import numpy as np
 from psygnal import Signal
 
+from typing import Optional
+
 from ...mda import MDAEngine
 from ._prop_event_mixin import _DevicePropertyEventMixin
 
@@ -25,7 +27,9 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     # added for CMMCorePlus
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
-    continuousSequenceAcquisition = Signal(bool)
+    startContinuousSequenceAcquisition = Signal()
+    startSequenceAcquisition = Signal(str, int, float, bool)
+    stopSequenceAcquisition = Signal()
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -25,6 +25,9 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     # added for CMMCorePlus
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
+    continuousSequenceAcquisition = Signal(bool)
+    groupDeleted = Signal(str)
+    presetDeleted = Signal(str, str)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -26,8 +26,6 @@ class CMMCoreSignaler(_DevicePropertyEventMixin):
     imageSnapped = Signal(np.ndarray)  # whenever snap is called
     mdaEngineRegistered = Signal(MDAEngine, MDAEngine)
     continuousSequenceAcquisition = Signal(bool)
-    groupDeleted = Signal(str)
-    presetDeleted = Signal(str, str)
 
     # aliases for lower casing
     @property

--- a/pymmcore_plus/core/events/_psygnal.py
+++ b/pymmcore_plus/core/events/_psygnal.py
@@ -1,8 +1,6 @@
 import numpy as np
 from psygnal import Signal
 
-from typing import Optional
-
 from ...mda import MDAEngine
 from ._prop_event_mixin import _DevicePropertyEventMixin
 

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,6 +26,8 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
+    autoShutterSet = Signal(bool)
+    shutterSet = Signal(str, bool)
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -30,7 +30,7 @@ class QCoreSignaler(QObject):
     startContinuousSequenceAcquisition = Signal()
     # when SequenceAcquisition is started
     startSequenceAcquisition = Signal(str, int, float, bool)
-    # when (Continuous)SequenceAcquisition is stopped 
+    # when (Continuous)SequenceAcquisition is stopped
     stopSequenceAcquisition = Signal(str)
     autoShutterSet = Signal(bool)
     shutterSet = Signal(str, bool)

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,15 +26,12 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
-    startContinuousSequenceAcquisition = (
-        Signal()
-    )  # when continuousSequenceAcquisition is started
-    startSequenceAcquisition = Signal(
-        str, int, float, bool
-    )  # when SequenceAcquisition is started
-    stopSequenceAcquisition = Signal(
-        str
-    )  # when (Continuous)SequenceAcquisition is stopped
+    # when continuousSequenceAcquisition is started
+    startContinuousSequenceAcquisition = Signal()
+    # when SequenceAcquisition is started
+    startSequenceAcquisition = Signal(str, int, float, bool)
+    # when (Continuous)SequenceAcquisition is stopped
+    stopSequenceAcquisition = Signal(str)
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,9 +26,15 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
-    startContinuousSequenceAcquisition = Signal() # when continuousSequenceAcquisition is started
-    startSequenceAcquisition = Signal(str, int, float, bool) # when SequenceAcquisition is started
-    stopSequenceAcquisition = Signal() # when (continuous)SequenceAcquisition is stopped
+    startContinuousSequenceAcquisition = (
+        Signal()
+    )  # when continuousSequenceAcquisition is started
+    startSequenceAcquisition = Signal(
+        str, int, float, bool
+    )  # when SequenceAcquisition is started
+    stopSequenceAcquisition = (
+        Signal()
+    )  # when (continuous)SequenceAcquisition is stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -33,7 +33,7 @@ class QCoreSignaler(QObject):
         str, int, float, bool
     )  # when SequenceAcquisition is started
     stopSequenceAcquisition = Signal(
-        object
+        str
     )  # when (Continuous)SequenceAcquisition is stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -32,8 +32,8 @@ class QCoreSignaler(QObject):
     startSequenceAcquisition = Signal(
         str, int, float, bool
     )  # when SequenceAcquisition is started
-    stopSequenceAcquisition = (
-        Signal(object)
+    stopSequenceAcquisition = Signal(
+        object
     )  # when (Continuous)SequenceAcquisition is stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,9 +26,7 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
-    continuousSequenceAcquisition = Signal(bool)  # for continuousSequenceAcquisition
-    groupDeleted = Signal(str)  # when a group is deleted
-    presetDeleted = Signal(str, str)  # when a  preset is deleted
+    continuousSequenceAcquisition = Signal(bool)  # when SequenceAcquisition is started/stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,7 +26,9 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
-    continuousSequenceAcquisition = Signal(bool)  # when SequenceAcquisition is started/stopped
+    continuousSequenceAcquisition = Signal(
+        bool
+    )  # when SequenceAcquisition is started/stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,7 +26,9 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
-    continuousSequenceAcquisition = Signal(bool)  # when SequenceAcquisition is started/stopped
+    startContinuousSequenceAcquisition = Signal() # when continuousSequenceAcquisition is started
+    startSequenceAcquisition = Signal(str, int, float, bool) # when SequenceAcquisition is started
+    stopSequenceAcquisition = Signal() # when (continuous)SequenceAcquisition is stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -26,6 +26,9 @@ class QCoreSignaler(QObject):
     # added for CMMCorePlus
     imageSnapped = Signal(object)  # after an image is snapped
     mdaEngineRegistered = Signal(object, object)  # new engine, old engine
+    continuousSequenceAcquisition = Signal(bool)  # for continuousSequenceAcquisition
+    groupDeleted = Signal(str)  # when a group is deleted
+    presetDeleted = Signal(str, str)  # when a  preset is deleted
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:

--- a/pymmcore_plus/core/events/_qsignals.py
+++ b/pymmcore_plus/core/events/_qsignals.py
@@ -33,8 +33,8 @@ class QCoreSignaler(QObject):
         str, int, float, bool
     )  # when SequenceAcquisition is started
     stopSequenceAcquisition = (
-        Signal()
-    )  # when (continuous)SequenceAcquisition is stopped
+        Signal(object)
+    )  # when (Continuous)SequenceAcquisition is stopped
 
     # can't use _DevicePropertyEventMixin due to metaclass conflict
     def __init__(self) -> None:


### PR DESCRIPTION
Adding 3 new `signals` and `pymmcore-plus` methods:

 - `groupDeleted` signal -> when a group is deleted
    - `deleteGroup` method 

 - `presetDeleted` signal -> when a preset is deleted
    - `deletePreset` method  

 -  `continuousSequenceAcquisition` signal -> when SequenceAcquisition a sequenceAcquisition is started or stopped
    - `startContinuousSeqAcquisition`/`stopSeqAcquisition` methods