### PR TITLE
Suggestion on 517

### DIFF
--- a/src/pymmcore_plus/mda/events/__init__.py
+++ b/src/pymmcore_plus/mda/events/__init__.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from pymmcore_plus._util import signals_backend
 
-from ._protocol import PMDASignaler, RunStatus
+from ._protocol import PMDASignaler
 from ._psygnal import MDASignaler
 
 if TYPE_CHECKING:
@@ -15,7 +15,6 @@ __all__ = [
     "MDASignaler",
     "PMDASignaler",
     "QMDASignaler",
-    "RunStatus",
     "_get_auto_MDA_callback_class",
 ]
 

--- a/src/pymmcore_plus/mda/events/_protocol.py
+++ b/src/pymmcore_plus/mda/events/_protocol.py
@@ -1,26 +1,6 @@
-from enum import Enum
 from typing import ClassVar, Protocol, runtime_checkable
 
 from pymmcore_plus.core.events._protocol import PSignal
-
-
-class RunStatus(str, Enum):
-    """Enumeration of the possible states of the MDA runner."""
-
-    IDLE = "idle"
-    RUNNING = "running"
-    PAUSE_TOGGLED = "pause toggled"
-    PAUSED = "paused"
-    CANCELING = "canceling"
-    CANCELED = "canceled"
-    ERROR = "error"
-    COMPLETED = "completed"
-
-    def __str__(self) -> str:
-        return str(self.value)
-
-    def __repr__(self) -> str:
-        return f"RunStatus.{self.name}"
 
 
 @runtime_checkable

--- a/tests/test_mda.py
+++ b/tests/test_mda.py
@@ -13,7 +13,7 @@ from useq import HardwareAutofocus, MDAEvent, MDASequence
 
 from pymmcore_plus import CMMCorePlus, FocusDirection
 from pymmcore_plus.mda._engine import _warn_focus_dir
-from pymmcore_plus.mda.events import MDASignaler, RunStatus
+from pymmcore_plus.mda.events import MDASignaler
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -51,7 +51,7 @@ def test_mda_waiting(core: CMMCorePlus) -> None:
 
 
 def test_setting_position(core: CMMCorePlus) -> None:
-    core.mda._status = RunStatus.RUNNING
+    core.mda._running = True
     event1 = MDAEvent(
         exposure=123,
         x_pos=123,
@@ -111,7 +111,7 @@ def test_mda_failures(core: CMMCorePlus, qtbot: QtBot) -> None:
 
     assert not core.mda.is_running()
     assert not core.mda.is_paused()
-    assert core.mda.status != RunStatus.CANCELED
+    assert not core.mda._canceled
     core.mda.events.frameReady.disconnect(cb)
 
     # Hardware failure
@@ -128,7 +128,7 @@ def test_mda_failures(core: CMMCorePlus, qtbot: QtBot) -> None:
                     core.mda.run(mda)
         assert not core.mda.is_running()
         assert not core.mda.is_paused()
-        assert core.mda.status != RunStatus.CANCELED
+        assert not core.mda._canceled
 
 
 # using a dict here instead of a useq.AxesBasedAF to force MDASequence to

--- a/tests/test_mda_status.py
+++ b/tests/test_mda_status.py
@@ -1,4 +1,4 @@
-"""Tests for MDA runner status management."""
+"""Tests for MDA runner pause/cancel during hardware sequences."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ import pytest
 from useq import MDASequence
 
 from pymmcore_plus._logger import logger
-from pymmcore_plus.mda.events import RunStatus
 
 if TYPE_CHECKING:
     from pytestqt.qtbot import QtBot
@@ -25,70 +24,6 @@ except ImportError:
 SKIP_NO_PYTESTQT = pytest.mark.skipif(
     pytestqt is None, reason="pytest-qt not installed"
 )
-
-
-def test_initial_status(core: CMMCorePlus) -> None:
-    """Test that the initial status is IDLE."""
-    assert core.mda.status == RunStatus.IDLE
-    assert not core.mda.is_running()
-    assert not core.mda.is_paused()
-
-
-@SKIP_NO_PYTESTQT
-def test_status_during_run(core: CMMCorePlus, qtbot: QtBot) -> None:
-    """Test status transitions during a normal MDA run."""
-    sequence = MDASequence(time_plan={"interval": 0.3, "loops": 5})
-
-    # Track status changes
-    status_changes: list[RunStatus] = []
-
-    def _track_status():
-        status_changes.append(core.mda.status)
-
-    def _on_finished(seq):
-        assert set(status_changes) == {
-            RunStatus.PAUSE_TOGGLED,
-            RunStatus.PAUSED,
-            RunStatus.RUNNING,
-            RunStatus.COMPLETED,
-        }
-        assert not core.mda.is_running()
-        assert not core.mda.is_paused()
-        assert not core.mda.is_canceled()
-
-    # Connect to signals to track status
-    core.mda.events.sequenceStarted.connect(_track_status)
-    core.mda.events.eventStarted.connect(lambda _: _track_status())
-    core.mda.events.awaitingEvent.connect(lambda _: _track_status())
-    core.mda.events.frameReady.connect(lambda _: _track_status())
-    core.mda.events.sequenceFinished.connect(lambda _: _track_status())
-    core.mda.events.sequenceFinished.connect(_on_finished)
-
-    # Check initial state
-    assert core.mda.status == RunStatus.IDLE
-
-    # Run the sequence
-    with qtbot.waitSignals(
-        (core.mda.events.sequenceFinished, core.mda.events.sequencePauseToggled),
-        timeout=10000,
-    ):
-        acq_thread = core.run_mda(sequence)
-        assert core.mda.is_running()
-        paused = False
-        while acq_thread.is_alive():
-            if not paused:
-                paused = True
-                time.sleep(0.3)
-                core.mda.toggle_pause()
-                assert core.mda.is_pause_requested()
-                status_changes.append(core.mda.status)
-                time.sleep(0.3)
-                assert core.mda.is_paused()
-                status_changes.append(core.mda.status)
-                core.mda.toggle_pause()
-                assert not core.mda.is_pause_requested()
-                assert not core.mda.is_paused()
-                status_changes.append(core.mda.status)
 
 
 @SKIP_NO_PYTESTQT
@@ -172,111 +107,3 @@ def test_sequenced_event_paused_and_cancelled(
     finally:
         logger.removeHandler(handler)
         logger.setLevel(original_level)
-
-
-def test_status_persistence_after_completion(core: CMMCorePlus) -> None:
-    """Test that terminal status persists after sequence finishes."""
-    # This is a synchronous test (no threading)
-    sequence = MDASequence(channels=["DAPI"], time_plan={"interval": 0.1, "loops": 2})
-
-    # Run synchronously
-    core.mda.run(sequence)
-
-    # Status should be COMPLETED
-    assert core.mda.status == RunStatus.COMPLETED
-    assert not core.mda.is_running()
-
-
-def test_toggle_pause_when_not_running(core: CMMCorePlus) -> None:
-    """Test that toggle_pause is a no-op when not running."""
-    assert core.mda.status == RunStatus.IDLE
-
-    # Should be no-op
-    core.mda.toggle_pause()
-
-    # Status should still be IDLE
-    assert core.mda.status == RunStatus.IDLE
-    assert not core.mda.is_paused()
-
-
-def test_cancel_when_not_running(core: CMMCorePlus) -> None:
-    """Test that cancel is a no-op when not running."""
-    assert core.mda.status == RunStatus.IDLE
-
-    # Should be no-op
-    core.mda.cancel()
-
-    # Status should still be IDLE
-    assert core.mda.status == RunStatus.IDLE
-
-
-def test_remaining_wait_time_calculation_with_pause(core: CMMCorePlus) -> None:
-    """Test that _get_remaining_wait_time recalculates with updated _paused_time.
-
-    This verifies the comment in _get_remaining_wait_time:
-    'We calculate remaining_wait_time fresh each iteration using
-    event.min_start_time + self._paused_time to ensure it stays correct
-    even when self._paused_time changes during pause.'
-
-    This is a unit test that directly tests the calculation logic,
-    simulating the scenario where pause time accumulates during a wait interval.
-    """
-    # Set up the runner with a known state
-    runner = core.mda
-    min_start_time = 4.0  # Event should start 4 seconds after t0
-
-    # Simulate starting the sequence
-    runner._t0 = time.perf_counter()
-    initial_t0 = runner._t0
-
-    # Initially, no pause time has accumulated
-    runner._paused_time = 0.0
-
-    # Calculate remaining wait time - should be close to 4.0 seconds
-    remaining_1 = runner._get_remaining_wait_time(min_start_time)
-    assert 3.9 < remaining_1 <= 4.0, f"Expected remaining time ~4.0s, got {remaining_1}"
-
-    # Simulate some time passing (1.0 seconds)
-    time.sleep(1.0)
-
-    # Without any pause, remaining time should decrease by ~1s
-    # More lenient bounds since sleep timing can vary
-    remaining_2 = runner._get_remaining_wait_time(min_start_time)
-    assert 2.7 < remaining_2 < 3.2, f"Expected remaining time ~3.0s, got {remaining_2}"
-
-    # Now simulate a pause accumulating (add 2.0 seconds of pause time)
-    # This simulates what happens when _handle_pause_state() accumulates time
-    runner._paused_time = 2.0
-
-    # The remaining wait time should be recalculated using the NEW paused_time
-    # Formula: min_start_time + paused_time - elapsed
-    # Expected: 4.0 + 2.0 - ~1.0 = ~5.0 seconds (but elapsed may vary slightly)
-    remaining_3 = runner._get_remaining_wait_time(min_start_time)
-    elapsed = time.perf_counter() - initial_t0
-    expected = min_start_time + runner._paused_time - elapsed
-    assert abs(remaining_3 - expected) < 0.2, (
-        f"Expected remaining time to be recalculated with new paused_time. "
-        f"Expected ~{expected:.2f}s, got {remaining_3:.2f}s. "
-        f"This confirms that the calculation uses the CURRENT paused_time value."
-    )
-
-    # Verify that the remaining time INCREASED compared to remaining_2
-    # because we added pause time (this is the key behavior)
-    assert remaining_3 > remaining_2, (
-        f"After adding paused_time, remaining wait should increase. "
-        f"Before pause: {remaining_2:.2f}s, after pause: {remaining_3:.2f}s. "
-        f"This demonstrates that _get_remaining_wait_time recalculates "
-        f"fresh each time using the current _paused_time value, maintaining "
-        f"the correct interval duration even when paused."
-    )
-
-    # Verify the timing makes sense: with 2s pause added to 4s interval,
-    # and ~1s already elapsed, we should have ~5s remaining
-    # More lenient bounds to account for sleep timing variations
-    assert 4.7 < remaining_3 < 5.3, (
-        f"Expected remaining time ~5.0s (4s interval + 2s pause - ~1s elapsed), "
-        f"got {remaining_3:.2f}s"
-    )
-
-    # Clean up
-    runner._paused_time = 0.0


### PR DESCRIPTION
trying to achieve the same thing as https://github.com/pymmcore-plus/pymmcore-plus/pull/517 ... with much less code, and (importantly) without the engine breaking separation of concerns and reaching back into the API of the Runner (self.mmcore.mda...)